### PR TITLE
Add win_arm64 platform support

### DIFF
--- a/test_wheel_matrix.py
+++ b/test_wheel_matrix.py
@@ -23,3 +23,11 @@ def test_universal2():
         ('cp38', 'mac', 'arm64'),
         ('cp39', 'mac', 'arm64'),
     }
+
+
+def test_windows_arm64():
+    """We can identify a Windows ARM64 wheel."""
+    assert get_triples(
+        'foo-1.0-cp311-cp311-win_arm64.whl',
+        cpythons=['cp311'],
+    ) == {('cp311', 'windows', 'arm64')}

--- a/wheel_matrix.py
+++ b/wheel_matrix.py
@@ -10,7 +10,7 @@ import re
 from packaging.utils import parse_wheel_filename
 from wcwidth import wcswidth
 
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 
 
 OS = str
@@ -20,7 +20,7 @@ PyVersion = str
 
 PLATFORMS = {
     'linux': ['x86_64', 'i686'],
-    'windows': ['win32', 'amd64'],
+    'windows': ['win32', 'amd64', 'arm64'],
     'mac': ['x86_64', 'arm64'],
 }
 
@@ -58,6 +58,9 @@ def get_os_arches(tag: str) -> Iterable[tuple[OS, Architecture]]:
         return
     elif tag == 'win_amd64':
         yield 'windows', 'amd64'
+        return
+    elif tag == 'win_arm64':
+        yield 'windows', 'arm64'
         return
     elif tag.startswith('macosx'):
         if tag.endswith('_universal2'):


### PR DESCRIPTION
## Summary
- support win_arm64 wheels in `get_os_arches`
- include Windows ARM64 in default platform list
- bump version to 0.3.2
- test wheel detection on Windows ARM64

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a3fc76a38832896123fe5bdee34d8