### PR TITLE
Fix docstring reference

### DIFF
--- a/wheel_matrix.py
+++ b/wheel_matrix.py
@@ -32,7 +32,7 @@ def get_arch(tag: str) -> Architecture:
     """Get the architecture targeted by a wheel platform tag.
 
     This only applies for certain OSes, so don't use this directly, use
-    get_os_arch() instead.
+    get_os_arches() instead.
     """
     if tag.endswith('_x86_64'):
         return 'x86_64'


### PR DESCRIPTION
## Summary
- fix wrong docstring in `get_arch`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a4b12d3d88328a742547c773cd89a