### PR TITLE
Implement --platforms option to select columns to show by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ Ensure you have Python 3.10 or newer to run `wheel-matrix`.
 To use `wheel-matrix`, run the following command in your terminal:
 
 ```bash
-wheel-matrix <package-name> [<version>]
+wheel-matrix <package-name> [<version>] [--all]
 ```
 
 - `<package-name>`: Name of the Python package for which to generate the wheel matrix.
 - `<version>`: (Optional) Specific version of the package. If not provided, the latest version will be used.
+- `--all`: Include every architecture known to the tool, even those without wheels.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ Ensure you have Python 3.10 or newer to run `wheel-matrix`.
 To use `wheel-matrix`, run the following command in your terminal:
 
 ```bash
-wheel-matrix <package-name> [<version>] [--all]
+wheel-matrix <package-name> [<version>] [--platforms=all]
 ```
 
 - `<package-name>`: Name of the Python package for which to generate the wheel matrix.
 - `<version>`: (Optional) Specific version of the package. If not provided, the latest version will be used.
-- `--all`: Include every architecture known to the tool, even those without wheels.
+- `--platforms=all`: Include every architecture known to the tool, instead of the recommended subset.
 
 Example:
 


### PR DESCRIPTION
## Summary
- drop legacy platforms from the default table and clarify the config
- add `--all` option to show every platform we know about
- document the flag in README

## Testing
- `pytest -q`
- `mypy wheel_matrix.py test_wheel_matrix.py`

------
https://chatgpt.com/codex/tasks/task_e_688a4fc1442c8328858b925b8a04e5f9