### PR TITLE
Don't attempt to publish if we haven't tagged

### DIFF
--- a/.github/workflows/auto_tag.yml
+++ b/.github/workflows/auto_tag.yml
@@ -55,4 +55,5 @@ jobs:
           git push origin "v$VERSION"
 
       - name: Publish package distributions to PyPI
+        if: steps.check-tag.outputs.exists == 'false'
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request introduces a conditional check to prevent publishing package distributions to PyPI if the tag already exists, improving workflow efficiency.

* [`.github/workflows/auto_tag.yml`](diffhunk://#diff-f17a3cc24a371dba3b13a9249dd40addc6f61462f2c2c5d73b1ef99368950417R58): Added a conditional `if` statement (`steps.check-tag.outputs.exists == 'false'`) to the "Publish package distributions to PyPI" step, ensuring that packages are only published if the tag does not already exist.