### PR TITLE
Fix unknown architecture error

### DIFF
--- a/test_wheel_matrix.py
+++ b/test_wheel_matrix.py
@@ -34,6 +34,22 @@ def test_windows_arm64():
     ) == {('cp311', 'windows', 'arm64')}
 
 
+def test_linux_ppc64le():
+    """We can identify a linux PPC64LE wheel."""
+    assert get_triples(
+        'foo-1.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl',
+        cpythons=['cp311'],
+    ) == {('cp311', 'linux', 'ppc64le')}
+
+
+def test_linux_s390x():
+    """We can identify a linux s390x wheel."""
+    assert get_triples(
+        'foo-1.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl',
+        cpythons=['cp311'],
+    ) == {('cp311', 'linux', 's390x')}
+
+
 def test_py3_none_any():
     """Pure Python wheels do not target a specific OS/architecture."""
     with pytest.raises(ValueError, match="platform tag 'any'"):

--- a/wheel_matrix.py
+++ b/wheel_matrix.py
@@ -34,10 +34,10 @@ RECOMMENDED_PLATFORMS: dict[OS, list[Architecture]] = {
 # Every OS/architecture combination we know about. New entries may still be
 # discovered when parsing wheel filenames.
 ALL_PLATFORMS: dict[OS, list[Architecture]] = {
-    'linux': ['x86_64', 'i686', 'aarch64'],
+    'linux': ['x86_64', 'i686', 'aarch64', 'ppc64le', 's390x'],
     'windows': ['win32', 'amd64', 'arm64'],
     'mac': ['x86_64', 'arm64'],
-    'musllinux': ['x86_64', 'i686', 'aarch64'],
+    'musllinux': ['x86_64', 'i686', 'aarch64', 'ppc64le', 's390x'],
 }
 
 Triple = tuple[PyVersion, OS, Architecture]
@@ -62,6 +62,16 @@ def get_arch(tag: str) -> Architecture:
         return 'aarch64'
     elif tag.endswith('_arm64'):
         return 'arm64'
+    elif tag.endswith('_ppc64le'):
+        return 'ppc64le'
+    elif tag.endswith('_ppc64'):
+        return 'ppc64'
+    elif tag.endswith('_s390x'):
+        return 's390x'
+    elif tag.endswith('_loongarch64'):
+        return 'loongarch64'
+    elif tag.endswith('_riscv64'):
+        return 'riscv64'
     raise ValueError(f'Unknown architecture for {tag}')
 
 


### PR DESCRIPTION
## Summary
- add support for ppc64le and s390x architectures
- include new archs in known platform lists
- test linux ppc64le and s390x wheel recognition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a64bce7b88328958b79ad73b24ecd