### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/wheel_matrix.py
+++ b/wheel_matrix.py
@@ -11,7 +11,7 @@ from packaging.utils import parse_wheel_filename
 from packaging.tags import Tag
 from wcwidth import wcswidth
 
-__version__ = '0.4.0'
+__version__ = '0.5.0'
 
 
 OS = str


### PR DESCRIPTION
## Summary
- bump version constant to 0.5.0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6890ade5b89c8328a95b6747c5fe7af5